### PR TITLE
Add missing $ arg to query

### DIFF
--- a/datascript_getting_started.md
+++ b/datascript_getting_started.md
@@ -78,13 +78,13 @@ A full `project.clj` file for a datascript only app would look like this.
 ;;; Query to find names for entities (people) whose age is less than 18
 (def q-young '[:find ?n
                :where
-               :in ?min-age
+               :in $ ?min-age
                [?e :name ?n]
                [?e :age ?a]
                [(< ?a ?min-age)]])
 
 ;; execute query: q-young, passing 18 as min-age
-(d/q q-young @conn 18)
+(d/q q-young 18)
 
 ;; Query Result
 ;; => [["Sally"]]


### PR DESCRIPTION
If your query has args, you need to make sure to bind the db input (only implicit if there are no other args to the query)