### PR TITLE
Fix example in javascript_integration.md

### DIFF
--- a/javascript_integration.md
+++ b/javascript_integration.md
@@ -47,6 +47,6 @@ d.transact(conn, datoms, "initial info about Igor and Ivan")
 // report is regular JS object'
 // query mori values from conn with CLJS API
 
-var result = d.q(parse('[:find ?n :in $ ?a :where [?e "friend" ?f] [?e "age" ?a] [?f "name" ?n]]'), d.db(conn), 18);
+var result = d.q('[:find ?n :in $ ?a :where [?e "friend" ?f] [?e "age" ?a] [?f "name" ?n]]', d.db(conn), 18);
 ```
 


### PR DESCRIPTION
`parse` is not defined and using `jsedn.parse` for it doesn't seem to work or be helpful. The example seems fine without `parse`.